### PR TITLE
Fix Issue #36; change mv to cp for attention modules.

### DIFF
--- a/Deforum_Stable_Diffusion.ipynb
+++ b/Deforum_Stable_Diffusion.ipynb
@@ -7,7 +7,7 @@
       },
       "source": [
         "# **Deforum Stable Diffusion v0.6**\n",
-        "[Stable Diffusion](https://github.com/CompVis/stable-diffusion) by Robin Rombach, Andreas Blattmann, Dominik Lorenz, Patrick Esser, Bj\u00f6rn Ommer and the [Stability.ai](https://stability.ai/) Team. [K Diffusion](https://github.com/crowsonkb/k-diffusion) by [Katherine Crowson](https://twitter.com/RiversHaveWings).\n",
+        "[Stable Diffusion](https://github.com/CompVis/stable-diffusion) by Robin Rombach, Andreas Blattmann, Dominik Lorenz, Patrick Esser, Björn Ommer and the [Stability.ai](https://stability.ai/) Team. [K Diffusion](https://github.com/crowsonkb/k-diffusion) by [Katherine Crowson](https://twitter.com/RiversHaveWings).\n",
         "\n",
         "[Quick Guide](https://docs.google.com/document/d/1RrQv7FntzOuLg4ohjRZPVL7iptIyBhwwbcEYEW2OfcI/edit?usp=sharing) to Deforum v0.6\n",
         "\n",
@@ -16,18 +16,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "IJjzzkKlWM_s"
       },
+      "outputs": [],
       "source": [
         "#@markdown **NVIDIA GPU**\n",
         "import subprocess, os, sys\n",
         "sub_p_res = subprocess.run(['nvidia-smi', '--query-gpu=name,memory.total,memory.free', '--format=csv,noheader'], stdout=subprocess.PIPE).stdout.decode('utf-8')\n",
         "print(f\"{sub_p_res[:-1]}\")"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "markdown",
@@ -40,10 +40,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "0D2HQO-PWM_t"
       },
+      "outputs": [],
       "source": [
         "\n",
         "import subprocess, time, gc, os, sys\n",
@@ -104,8 +106,8 @@
         "            all_process = [\n",
         "                ['wget', x_link],\n",
         "                ['pip', 'install', x_ver],\n",
-        "                ['mv', 'deforum-stable-diffusion/src/ldm/modules/attention.py', 'deforum-stable-diffusion/src/ldm/modules/attention_backup.py'],\n",
-        "                ['mv', 'deforum-stable-diffusion/src/ldm/modules/attention_xformers.py', 'deforum-stable-diffusion/src/ldm/modules/attention.py']\n",
+        "                ['cp', 'deforum-stable-diffusion/src/ldm/modules/attention.py', 'deforum-stable-diffusion/src/ldm/modules/attention_backup.py'],\n",
+        "                ['cp', 'deforum-stable-diffusion/src/ldm/modules/attention_xformers.py', 'deforum-stable-diffusion/src/ldm/modules/attention.py']\n",
         "            ]\n",
         "\n",
         "            for process in all_process:\n",
@@ -160,9 +162,7 @@
         "                                    , \n",
         "                                    check_sha256=True\n",
         "                                    )"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "markdown",
@@ -175,10 +175,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "E0tJVYA4WM_u"
       },
+      "outputs": [],
       "source": [
         "def DeforumAnimArgs():\n",
         "\n",
@@ -235,15 +237,15 @@
         "    resume_timestring = \"20220829210106\" #@param {type:\"string\"}\n",
         "\n",
         "    return locals()"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "i9fly1RIWM_u"
       },
+      "outputs": [],
       "source": [
         "prompts = [\n",
         "    \"a beautiful lake by Asher Brown Durand, trending on Artstation\", # the first prompt I want\n",
@@ -260,16 +262,16 @@
         "    30: \"a beautiful coconut, trending on Artstation\",\n",
         "    40: \"a beautiful durian, trending on Artstation\",\n",
         "}"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "XVzhbmizWM_u"
       },
+      "outputs": [],
       "source": [
         "#@markdown **Load Settings**\n",
         "override_settings_with_file = False #@param {type:\"boolean\"}\n",
@@ -429,9 +431,7 @@
         "    render_interpolation(args, anim_args, animation_prompts, root)\n",
         "else:\n",
         "    render_image_batch(args, prompts, root)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "markdown",
@@ -444,10 +444,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "XQGeqaGAWM_v"
       },
+      "outputs": [],
       "source": [
         "skip_video_for_run_all = True #@param {type: 'boolean'}\n",
         "fps = 12 #@param {type:\"number\"}\n",
@@ -522,16 +524,16 @@
         "             gif_path\n",
         "         ]\n",
         "         process_gif = subprocess.Popen(cmd_gif, stdout=subprocess.PIPE, stderr=subprocess.PIPE)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "id": "MMpAcyrYWM_v"
       },
+      "outputs": [],
       "source": [
         "skip_disconnect_for_run_all = True #@param {type: 'boolean'}\n",
         "\n",
@@ -540,12 +542,15 @@
         "else:\n",
         "    from google.colab import runtime\n",
         "    runtime.unassign()"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     }
   ],
   "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "provenance": []
+    },
+    "gpuClass": "standard",
     "kernelspec": {
       "display_name": "Python 3.10.6 ('dsd')",
       "language": "python",
@@ -568,12 +573,7 @@
       "interpreter": {
         "hash": "b7e04c8a9537645cbc77fa0cbde8069bc94e341b0d5ced104651213865b24e58"
       }
-    },
-    "colab": {
-      "provenance": []
-    },
-    "accelerator": "GPU",
-    "gpuClass": "standard"
+    }
   },
   "nbformat": 4,
   "nbformat_minor": 4

--- a/Deforum_Stable_Diffusion.py
+++ b/Deforum_Stable_Diffusion.py
@@ -90,11 +90,12 @@ def setup_environment():
             x_ver = 'xformers-0.0.13.dev0-py3-none-any.whl'
             x_link = 'https://github.com/TheLastBen/fast-stable-diffusion/raw/main/precompiled/' + name_to_download + '/' + x_ver
         
+            # Copy ensures that notebook works even if the repo is already cloned.
             all_process = [
                 ['wget', x_link],
                 ['pip', 'install', x_ver],
-                ['mv', 'deforum-stable-diffusion/src/ldm/modules/attention.py', 'deforum-stable-diffusion/src/ldm/modules/attention_backup.py'],
-                ['mv', 'deforum-stable-diffusion/src/ldm/modules/attention_xformers.py', 'deforum-stable-diffusion/src/ldm/modules/attention.py']
+                ['cp', 'deforum-stable-diffusion/src/ldm/modules/attention.py', 'deforum-stable-diffusion/src/ldm/modules/attention_backup.py'],
+                ['cp', 'deforum-stable-diffusion/src/ldm/modules/attention_xformers.py', 'deforum-stable-diffusion/src/ldm/modules/attention.py']
             ]
 
             for process in all_process:


### PR DESCRIPTION
_Note: Fix copied from Issue #36 comment section_

I fixed the issue, line 57 - 62 of the setup cell only work once.

```python
 all_process = [
                ['wget', x_link],
                ['pip', 'install', x_ver],
                ['mv', 'deforum-stable-diffusion/src/ldm/modules/attention.py', 'deforum-stable-diffusion/src/ldm/modules/attention_backup.py'],
                ['mv', 'deforum-stable-diffusion/src/ldm/modules/attention_xformers.py', 'deforum-stable-diffusion/src/ldm/modules/attention.py']
            ]
````

If we click _Runtime_ > _Restart and run all_ when the `deforum_stable_diffusion` repository has already been cloned, the two move commands above do not execute correctly. When they are executed a second time the `attention.py` and `attention_xformers` files do not exist. This is why we get the error:

```python
ModuleNotFoundError: No module named 'ldm.modules.attention'
```

## Simple fix for users

Click _Runtime_ > _Disconnect and delete runtime_. Re-open the notebook freshly, check the file and make sure `deforum_stable_diffusion` isn't there. And run the script again.

## Simple fix for codebase

The simplest fix for the codebase is to replace the `mv` commands with `cp`. This makes a copy of the files, rather than moving and overwriting the existing file. In this case, now if we run _Runtime_ > _Restart and run all_, the `attention_xformers.py` and `attention.py` files will still exist, and the error won't happen.

```python
 all_process = [
                ['wget', x_link],
                ['pip', 'install', x_ver],
                ['cp', 'deforum-stable-diffusion/src/ldm/modules/attention.py', 'deforum-stable-diffusion/src/ldm/modules/attention_backup.py'],
                ['cp', 'deforum-stable-diffusion/src/ldm/modules/attention_xformers.py', 'deforum-stable-diffusion/src/ldm/modules/attention.py']
            ]
````