### PR TITLE
fix resume issue w/ depth maps saved in output dir

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -116,7 +116,9 @@ def render_animation(args, anim_args, animation_prompts, root):
     start_frame = 0
     if anim_args.resume_from_timestring:
         for tmp in os.listdir(args.outdir):
-            if tmp.split("_")[0] == anim_args.resume_timestring:
+            filename = tmp.split("_")
+            # don't use saved depth maps to count number of frames
+            if anim_args.resume_timestring in filename and "depth" not in filename:
                 start_frame += 1
         start_frame = start_frame - 1
 


### PR DESCRIPTION
Before, the depth maps would interfere with counting of the number of frames. This change includes filenames that contain the resume timestring, but does not include those that are depth maps.

change also made in the automatic web-ui repo:
https://github.com/deforum-art/deforum-for-automatic1111-webui/pull/155