### PR TITLE
adding arg in render_image_batch

### DIFF
--- a/helpers/render.py
+++ b/helpers/render.py
@@ -77,6 +77,7 @@ def next_seed(args):
 
 def render_image_batch(args, prompts, root):
     args.prompts = {k: f"{v:05d}" for v, k in enumerate(prompts)}
+    args.using_vid_init = False
     
     # create output folder for the batch
     os.makedirs(args.outdir, exist_ok=True)


### PR DESCRIPTION
when rendering a batch of images, `args.using_vid_init` wasn't getting set, adding it in here, should always be False when rendering a batch of images.